### PR TITLE
Update bin/update-cesm-machines to v1.1.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ XML files configuring the system environment
 
 ### Modifying machine files
 
-We provide XML files with the configuration settings for Hydra (VSC Tier-2 HPC) and Breniac (VSC Tier-1 HPC). These files are located in `machines/` and cover *machines*, *compilers* and *batch* configurations. The settings for Hydra and Breniac can be easily added to the default machine files in CIME with the tool `update-cesm-machines`, which can update one file at a time. For instance, `config_compiler.xml` can be updated from the base of `sisc-hpc/cesm-config` with the command
+We provide XML files with the configuration settings for Hydra (VSC Tier-2 HPC) and Breniac (VSC Tier-1 HPC). These files are located in `machines/` and cover *machines*, *compilers* and *batch* configurations. The settings for Hydra and Breniac can be easily added to the default machine files in CIME with the tool `update-cesm-machines`. For instance, the aforementioned machine files can be updated with the additional settings from `sisc-hpc/cesm-config` with the command
 
 ```
-update-cesm-machines /path/to/cime/config/cesm/machines/config_compiler.xml machines/config_compiler.xml
+update-cesm-machines /path/to/cesm-x.y.z/cime/config/cesm/machines/ /path/to/cesm-config/machines/ machines compilers batch
 ```
 
 All three machine files (*machines*, *compilers* and *batch*) have to be updated to get a working installation of CESM/CIME in Hydra or Breniac.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Instruction to use CESM/CIME with iRODS:
 ssh irods.tier1.leuven.vsc | bash
 ```
 
-2. Create a collection for CESM input data
+2. Create a collection for CESM input data (only needed the first time)
 
 ```
 imkdir -p cesm/inputdata
@@ -115,7 +115,7 @@ cd cime/
 git description --tags
 ```
 
-4. Patch your source code of CESM/CIME to enable support for iRODS (choose closest version of the patch available)
+4. Patch your source code of CESM/CIME to enable support for iRODS. Choose the closest version of the patch available in `sisc-hpc/cesm-config`
 
 ```
 cd /path/to/cesm-2.1.3

--- a/bin/update-cesm-machines
+++ b/bin/update-cesm-machines
@@ -38,7 +38,7 @@ import sys
 
 from lxml import etree
 
-VERSION = '1.0.0'
+VERSION = '1.1.0'
 
 logging.basicConfig(
     format='%(asctime)s - %(levelname)s: %(message)s', datefmt='%d-%m-%Y %H:%M:%S', level=logging.INFO,
@@ -139,49 +139,30 @@ class MachineFile:
 
         # Save updated machine file
         self.tree.write(self.xml['path'], xml_declaration=True, pretty_print=True, with_comments=True)
-        logger.info("Succesfully saved updated machine file to '{}'".format(self.xml['path']))
+        logger.info("Succesfully saved the updated machine file to '{}'".format(self.xml['path']))
 
 
-def main():
-
-    # Parse command line arguments
-    cli = argparse.ArgumentParser(
-        prog='update-cesm-machines',
-        description='Update machine configuration files in CESM v2 with additional settings from external XML file.',
-    )
-    cli.add_argument(
-        'machine_file', default=None, help='Path to machine file in CESM',
-    )
-    cli.add_argument(
-        'extra_file', default=None, help='Path to extra XML file to include in the CESM machine file',
-    )
-    cli.add_argument(
-        '-d', '--debug', dest='debug', action='store_true', required=False, help='Enable debug verbosity',
-    )
-    cli.add_argument('-v', '--version', action='version', version='%(prog)s {}'.format(VERSION))
-    args = cli.parse_args()
-
-    # Set log level
-    if args.debug:
-        logger.setLevel(logging.DEBUG)
-
+def single_xml_merge(machine_filepath, extra_filepath):
+    """
+    Read the contents of extra XML file, merge them into the machine XML file and save
+    """
     # Machine XML file
     try:
-        base_machine = MachineFile(args.machine_file)
+        base_machine = MachineFile(machine_filepath)
     except IOError as err:
-        error_exit("Cannot read base machine file '{}'".format(args.machine_file), err)
+        error_exit("Cannot read base machine file '{}'".format(machine_filepath), err)
     except etree.XMLSyntaxError as err:
-        error_exit("Base machine file '{}' is malformed".format(args.machine_file), err)
+        error_exit("Base machine file '{}' is malformed".format(machine_filepath), err)
     else:
         logger.info("Succesfuly loaded base machine file '{}'".format(base_machine.xml['path']))
 
     # Extra XML file
     try:
-        extra_machine = MachineFile(args.extra_file)
+        extra_machine = MachineFile(extra_filepath)
     except IOError as err:
-        error_exit("Cannot read extra XML file '{}'".format(args.extra_file), err)
+        error_exit("Cannot read extra XML file '{}'".format(extra_filepath), err)
     except etree.XMLSyntaxError as err:
-        error_exit("Extra XML file '{}' is malformed".format(args.extra_file), err)
+        error_exit("Extra XML file '{}' is malformed".format(extra_filepath), err)
     else:
         logger.info("Succesfuly loaded extra XML file '{}'".format(extra_machine.xml['path']))
 
@@ -199,6 +180,63 @@ def main():
         base_machine.save_updated_xmlfile()
     except IOError as err:
         error_exit("Failed to write updated machine file to '{}'".format(base_machine.xml['path']), err)
+
+
+def main():
+
+    # Parse command line arguments
+    cli = argparse.ArgumentParser(
+        prog='update-cesm-machines',
+        description="Update machine configuration files in CESM v2 with additional settings from external XML files.",
+    )
+    cli.add_argument(
+        'cesm_path', default=None, help="Path to directory cime/config/cesm/machines in CESM",
+    )
+    cli.add_argument(
+        'external_path', default=None, help="Path to external directory with extra XML files",
+    )
+    cli.add_argument(
+        'machine_files',
+        help=(
+            "CESM machine files to process. Known machine files are batch, compilers and machines. "
+            "Option 'other' allows to update any arbitrary machine file."
+        ),
+        choices=['batch', 'compilers', 'machines', 'other'],
+        nargs='+',
+    )
+    cli.add_argument(
+        '-d', '--debug', dest='debug', action='store_true', required=False, help='Enable debug verbosity',
+    )
+    cli.add_argument('-v', '--version', action='version', version='%(prog)s {}'.format(VERSION))
+    args = cli.parse_args()
+
+    # Set log level
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    # Option 'other' is exclusive
+    if 'other' in args.machine_files:
+        if len(args.machine_files) > 1:
+            non_other_mf = [mf for mf in args.machine_files if mf != 'other']
+            logger.warning("Option 'other' is exclusive, ignoring: {}".format(', '.join(non_other_mf)))
+
+        if os.path.isdir(args.cesm_path) or os.path.isdir(args.external_path):
+            error_exit("Provided path is a directory. Option 'other' requires two XML files")
+        else:
+            single_xml_merge(args.cesm_path, args.external_path)
+
+    # The rest of options are known files
+    else:
+        for input_dir in [args.cesm_path, args.cesm_path]:
+            if not os.path.isdir(input_dir):
+                error_exit("Provided path is not a directory: {}".format(input_dir))
+
+        for machine_file in args.machine_files:
+            machine_xml = 'config_{}.xml'.format(machine_file)
+            cesm_machine_filepath = os.path.join(args.cesm_path, machine_xml)
+            extra_machine_filepath = os.path.join(args.external_path, machine_xml)
+
+            single_xml_merge(cesm_machine_filepath, extra_machine_filepath)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add option to update all three machine files in CIME with a single command.
```
update-cesm-machines /path/to/cesm-x.y.z/cime/config/cesm/machines/ /path/to/cesm-config/machines/ machines compilers batch
```

Previous operation on single machine files is still possible
```
update-cesm-machines /path/to/cesm-x.y.z/cime/config/cesm/machines/ /path/to/cesm-config/machines/ compilers
```

Or for any machine file, even if it is not known
```
update-cesm-machines /path/to/cesm-machine-file.xml /path/to/external-machine-file.xml other
```