### PR TITLE
Update to v1.3

### DIFF
--- a/easyconfigs/CESM-deps/CESM-deps-2-foss-2019a.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-foss-2019a.eb
@@ -10,7 +10,7 @@ description = """CESM is a fully-coupled, community, global climate model that p
 toolchain = {'name': 'foss', 'version': '2019a'}
 
 source_urls = ['https://github.com/sisc-hpc/cesm-config/archive/']
-sources = ['v1.2.tar.gz']
+sources = ['v1.3.tar.gz']
 
 dependencies = [
     ('CMake', '3.13.3'),

--- a/easyconfigs/CESM-deps/CESM-deps-2-intel-2018a.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-intel-2018a.eb
@@ -10,7 +10,7 @@ description = """CESM is a fully-coupled, community, global climate model that p
 toolchain = {'name': 'intel', 'version': '2018a'}
 
 source_urls = ['https://github.com/sisc-hpc/cesm-config/archive/']
-sources = ['v1.2.tar.gz']
+sources = ['v1.3.tar.gz']
 
 dependencies = [
     ('CMake', '3.11.4'),

--- a/irods/cime-5.6.19/01-CIME-fix-download-server-fallback.patch
+++ b/irods/cime-5.6.19/01-CIME-fix-download-server-fallback.patch
@@ -5,15 +5,17 @@ author: Alex Domingo (Vrije Universiteit Brussel)
 diff -W 126 -Nru cesm-2.1.2-orig/cime/scripts/lib/CIME/case/check_input_data.py cesm-2.1.2/cime/scripts/lib/CIME/case/check_input_data.py
 --- a/cime/scripts/lib/CIME/case/check_input_data.py	2020-08-14 22:06:06.241002000 +0200
 +++ b/cime/scripts/lib/CIME/case/check_input_data.py	2020-08-14 23:08:23.086486481 +0200
-@@ -273,7 +273,6 @@
+@@ -273,7 +273,8 @@
      data_list_files = find_files(data_list_dir, "*.input_data_list")
      expect(data_list_files, "No .input_data_list files found in dir '{}'".format(data_list_dir))
  
 -    no_files_missing = True
++    chksum_required = ["svn", "gftp", "ftp", "wget"]
++
      if download:
          if protocol not in vars(CIME.Servers):
              logger.warning("Client protocol {} not enabled".format(protocol))
-@@ -290,6 +289,7 @@
+@@ -290,6 +291,7 @@
          else:
              expect(False, "Unsupported inputdata protocol: {}".format(protocol))
  
@@ -21,7 +23,7 @@ diff -W 126 -Nru cesm-2.1.2-orig/cime/scripts/lib/CIME/case/check_input_data.py 
      for data_list_file in data_list_files:
          logging.info("Loading input file list: '{}'".format(data_list_file))
          with open(data_list_file, "r") as fd:
-@@ -303,6 +303,7 @@
+@@ -303,6 +305,7 @@
                  if description.endswith('datapath'):
                      continue
                  if(full_path):
@@ -29,7 +31,7 @@ diff -W 126 -Nru cesm-2.1.2-orig/cime/scripts/lib/CIME/case/check_input_data.py 
                      # expand xml variables
                      full_path = case.get_resolved_value(full_path)
                      rel_path  = full_path.replace(input_data_root, "")
-@@ -315,9 +316,9 @@
+@@ -315,9 +318,9 @@
                          if not os.path.exists(full_path):
                              logging.warning("Model {} missing file {} = '{}'".format(model, description, full_path))
                              if download:
@@ -41,7 +43,7 @@ diff -W 126 -Nru cesm-2.1.2-orig/cime/scripts/lib/CIME/case/check_input_data.py 
                              logging.debug("  Found input file: '{}'".format(full_path))
                      else:
                          # There are some special values of rel_path that
-@@ -330,24 +331,28 @@
+@@ -330,24 +333,28 @@
  
                          if ("/" in rel_path and not os.path.exists(full_path)):
                              logger.warning("  Model {} missing file {} = '{}'".format(model, description, full_path))
@@ -53,10 +55,11 @@ diff -W 126 -Nru cesm-2.1.2-orig/cime/scripts/lib/CIME/case/check_input_data.py 
                                                                          input_data_root, rel_path.strip(os.sep),
                                                                          isdirectory=isdirectory)
 -                                if no_files_missing:
-+                                if file_installed:
++                                if file_installed and protocol in chksum_required:
                                      verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)
                          else:
-                             if chksum:
+-                            if chksum:
++                            if chksum and protocol in chksum_required:
                                  verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)
                                  logger.info("Chksum passed for file {}".format(os.path.join(input_data_root,rel_path)))
 +                            file_installed = True

--- a/irods/cime-5.6.19/02-CIME-add-irods-server.patch
+++ b/irods/cime-5.6.19/02-CIME-add-irods-server.patch
@@ -107,7 +107,7 @@ diff -W 126 -Nru cesm-2.1.2-orig/cime/scripts/lib/CIME/Servers/irods.py cesm-2.1
 +    def getdirectory(self, rel_path, full_path):
 +        full_url = os.path.join(self._server_loc, rel_path)
 +        stat, output, errput = \
-+            run_cmd("irsync {} -r {}".format(self._args, full_url+os.sep), from_dir=full_path)
++            run_cmd("irsync {} -r {} ./".format(self._args, full_url+os.sep), from_dir=full_path)
 +        logger.debug(output)
 +        logger.debug(errput)
 +        if (stat != 0):

--- a/irods/cime-5.6.32/01-CIME-fix-download-server-fallback.patch
+++ b/irods/cime-5.6.32/01-CIME-fix-download-server-fallback.patch
@@ -5,15 +5,17 @@ author: Alex Domingo (Vrije Universiteit Brussel)
 diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/case/check_input_data.py cesm-2.1.3/cime/scripts/lib/CIME/case/check_input_data.py
 --- a/cime/scripts/lib/CIME/case/check_input_data.py	2020-08-14 22:11:33.487882000 +0200
 +++ b/cime/scripts/lib/CIME/case/check_input_data.py	2020-08-15 00:06:17.352015069 +0200
-@@ -276,7 +276,6 @@
+@@ -276,7 +276,8 @@
      data_list_files = find_files(data_list_dir, "*.input_data_list")
      expect(data_list_files, "No .input_data_list files found in dir '{}'".format(data_list_dir))
  
 -    no_files_missing = True
++    chksum_required = ["svn", "gftp", "ftp", "wget"]
++
      if download:
          if protocol not in vars(CIME.Servers):
              logger.warning("Client protocol {} not enabled".format(protocol))
-@@ -295,6 +294,7 @@
+@@ -295,6 +296,7 @@
          if not server:
              return False
  
@@ -21,7 +23,7 @@ diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/case/check_input_data.py 
      for data_list_file in data_list_files:
          logging.info("Loading input file list: '{}'".format(data_list_file))
          with open(data_list_file, "r") as fd:
-@@ -308,6 +308,7 @@
+@@ -308,6 +310,7 @@
                  if description.endswith('datapath'):
                      continue
                  if(full_path):
@@ -29,7 +31,7 @@ diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/case/check_input_data.py 
                      # expand xml variables
                      full_path = case.get_resolved_value(full_path)
                      rel_path  = full_path.replace(input_data_root, "")
-@@ -320,9 +321,9 @@
+@@ -320,9 +323,9 @@
                          if not os.path.exists(full_path):
                              logging.warning("Model {} missing file {} = '{}'".format(model, description, full_path))
                              if download:
@@ -41,7 +43,7 @@ diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/case/check_input_data.py 
                              logging.debug("  Found input file: '{}'".format(full_path))
                      else:
                          # There are some special values of rel_path that
-@@ -335,24 +336,28 @@
+@@ -335,24 +338,28 @@
  
                          if ("/" in rel_path and not os.path.exists(full_path)):
                              logger.warning("  Model {} missing file {} = '{}'".format(model, description, full_path))
@@ -53,10 +55,11 @@ diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/case/check_input_data.py 
                                                                          input_data_root, rel_path.strip(os.sep),
                                                                          isdirectory=isdirectory)
 -                                if no_files_missing:
-+                                if file_installed:
++                                if file_installed and protocol in chksum_required:
                                      verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)
                          else:
-                             if chksum:
+-                            if chksum:
++                            if chksum and protocol in chksum_required:
                                  verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)
                                  logger.info("Chksum passed for file {}".format(os.path.join(input_data_root,rel_path)))
 +                            file_installed = True
@@ -74,4 +77,3 @@ diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/case/check_input_data.py 
  
  def verify_chksum(input_data_root, rundir, filename, isdirectory):
      """
-Binary files cesm-2.1.3-orig/.git/index and cesm-2.1.3/.git/index differ

--- a/irods/cime-5.6.32/02-CIME-add-irods-server.patch
+++ b/irods/cime-5.6.32/02-CIME-add-irods-server.patch
@@ -62,7 +62,7 @@ diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/Servers/__init__.py cesm-
 diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/Servers/irods.py cesm-2.1.3/cime/scripts/lib/CIME/Servers/irods.py
 --- a/cime/scripts/lib/CIME/Servers/irods.py	1970-01-01 01:00:00.000000000 +0100
 +++ b/cime/scripts/lib/CIME/Servers/irods.py	2020-08-15 00:39:47.787846000 +0200
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,76 @@
 +"""
 +iRODS Server class.  Interact with a server using WGET protocol
 +"""
@@ -74,7 +74,7 @@ diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/Servers/irods.py cesm-2.1
 +
 +class IRODS(GenericServer):
 +    def __init__(self, address, user='', passwd=''):
-+        self._args = '-K '  # verify checksums
++        self._args = '-K'  # verify checksums
 +        self._server_loc = address
 +
 +    @classmethod
@@ -104,10 +104,12 @@ diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/Servers/irods.py cesm-2.1
 +
 +    def getfile(self, rel_path, full_path):
 +        full_url = os.path.join(self._server_loc, rel_path)
-+        stat, output, errput = \
-+                run_cmd("irsync {} {} {}".format(self._args, full_url, full_path))
++        irods_cmd = "irsync {} {} {}".format(self._args, full_url, full_path)
++        stat, output, errput = run_cmd(irods_cmd)
 +        if (stat != 0):
-+            logging.warning("irsync failed with output: {} and errput {}\n".format(output.encode('utf-8'), errput.encode('utf-8')))
++            logging.warning("{} failed with output: {} and errput {}\n".format(
++                irods_cmd, output.encode('utf-8'), errput.encode('utf-8')
++            ))
 +            # file might be empty or partially downloaded if it fails
 +            try:
 +                os.remove(full_path)
@@ -120,12 +122,14 @@ diff -W 126 -Nru cesm-2.1.3-orig/cime/scripts/lib/CIME/Servers/irods.py cesm-2.1
 +
 +    def getdirectory(self, rel_path, full_path):
 +        full_url = os.path.join(self._server_loc, rel_path)
-+        stat, output, errput = \
-+            run_cmd("irsync {} -r {}".format(self._args, full_url+os.sep), from_dir=full_path)
++        irods_cmd = "irsync {} -r {} ./".format(self._args, full_url+os.sep)
++        stat, output, errput = run_cmd(irods_cmd, from_dir=full_path)
 +        logger.debug(output)
 +        logger.debug(errput)
 +        if (stat != 0):
-+            logging.warning("irsync failed with output: {} and errput {}\n".format(output.encode('utf-8'), errput.encode('utf-8')))
++            logging.warning("{} failed with output: {} and errput {}\n".format(
++                irods_cmd, output.encode('utf-8'), errput.encode('utf-8')
++            ))
 +            # dir might be empty or partially downloaded if it fails
 +            try:
 +                os.remove(full_path)

--- a/irods/cime-5.6.32/03-CIME-archive-inputdata-irods.patch
+++ b/irods/cime-5.6.32/03-CIME-archive-inputdata-irods.patch
@@ -1,18 +1,20 @@
 Sync the local input data folder with the remote iRODS server in the archival step
 author: Alex Domingo (Vrije Universiteit Brussel)
 diff -W 126 -Nru cesm-2.1.3-orig/cime/config/cesm/machines/config_workflow.xml cesm-2.1.3/cime/config/cesm/machines/config_workflow.xml
---- a/cime/config/cesm/machines/config_workflow.xml	2020-08-14 22:11:22.305950000 +0200
-+++ b/cime/config/cesm/machines/config_workflow.xml	2020-08-15 10:46:48.984021000 +0200
-@@ -45,7 +45,7 @@
+--- a/cime/config/cesm/machines/config_workflow.xml	2020-08-27 18:57:04.136989000 +0200
++++ b/cime/config/cesm/machines/config_workflow.xml	2020-08-27 19:09:04.666168000 +0200
+@@ -44,8 +44,8 @@
+       <prereq>$DOUT_S</prereq>
        <runtime_parameters>
  	<task_count>1</task_count>
- 	<tasks_per_node>1</tasks_per_node>
+-	<tasks_per_node>1</tasks_per_node>
 -	<walltime>0:20:00</walltime>
++	<tasks_per_node>4</tasks_per_node>
 +	<walltime>12:00:00</walltime>
        </runtime_parameters>
      </job>
    </workflow_jobs>
-diff -W 126 -Nru cesm-2.1.2-orig/cime/config/cesm/machines/template.st_archive cesm-2.1.2/cime/config/cesm/machines/template.st_archive
+diff -W 126 -Nru cesm-2.1.3-orig/cime/config/cesm/machines/template.st_archive cesm-2.1.3/cime/config/cesm/machines/template.st_archive
 --- a/cime/config/cesm/machines/template.st_archive	2020-08-14 22:05:57.824547000 +0200
 +++ b/cime/config/cesm/machines/template.st_archive	2020-08-14 23:47:21.828084000 +0200
 @@ -17,6 +17,8 @@

--- a/scripts/case.job
+++ b/scripts/case.job
@@ -6,7 +6,6 @@ module load CESM-deps/2-foss-2019a
 cd $PBS_O_WORKDIR
 
 # Runtime settings
-./xmlchange BATCH_COMMAND_FLAGS="-V -l feature=$VSC_ARCH_LOCAL"
 ./xmlchange NTASKS=${PBS_NP}
 ./xmlchange DOUT_S=FALSE
 


### PR DESCRIPTION
Changelog:
* fix `irsync` command for recursive copies of directories
* data transfer from iRODS will rely on its own checksum verification, instead of the checksum from CIME
* archival jobs increased from 1 to 4 cores as iRODS can benefit from multiple cores
* remove unused setting from example job script