### PR TITLE
Update for intel/2019b

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All three machine files (*machines*, *compilers* and *batch*) have to be updated
 
 * Using `--machine hydra` is optional as long the user is in a compute node or a login node in Hydra. CESM uses `NODENAME_REGEX` in `config_machines.xml` to identify the host machine.
 * The only module needed is `CESM-deps`. It has to be loaded at all times, from cloning of the sources to case submission.
-* There is a single configuration for the compiler that is agnostic of the CPU architecture.
+* There is a single configuration for the compiler that is tailored to nodes with Skylake CPUs, including the login nodes.
 * CESM is not capable of detecting and automatically adding the required libraries to its build process. The current specification of `SLIBS` contains just what we found so far to be required.
 * By design, CESM sets a specific queue with `-q queue_name`, otherwise it fails to even create the case. In Hydra we have the queue `submission` for this purpose.
 * Limit maximum number of nodes to 10 to ensure that the scale of CESM jobs stay within reasonable limits for Hydra.
@@ -83,9 +83,9 @@ $VSC_SCRATCH
 The contents of the input data are mainly historical weather records, being actively accessed during the simulation in read operations, but not modified or created by running cases. Input data files are automatically downloaded by CIME into `DIN_LOC_ROOT` before the case is submitted to the queue. Only missing files that are needed to run the current simulation will be downloaded. Therefore, the contents of `DIN_LOC_ROOT` will grow over time, easily reaching several TB of data distributed in several thousands files ranging from a few hundred MB to several GB. Given the characteristics of the input data, it is very compelling to have a centralized storage for CESM input data that can be shared by multiple users.
 
 
-### Projects in Hydra
+### Data storage in Hydra
 
-In Hydra, the collection of input data files can be stored in the research group's own Virtual Organization (VO). Users can simply link their `DIN_LOC_ROOT` in `$VSC_SCRATCH` to it. This storage is as fast as `$VSC_SCRATCH` and can be used during the execution of the case without hindering its performance.
+In Hydra, the collection of input data files is stored by default in the user's scratch storage, `DIN_LOC_ROOT` is defined under `$VSC_SCRATCH`. Alternatively, user's part of a Virtual Organization (VO) can link their `DIN_LOC_ROOT` to the respective folder in `$VSC_SCRATCH_VO` or `$VSC_DATA_VO` of their VO. This storage is as fast as `$VSC_SCRATCH` and can be used during the execution of the case without hindering its performance.
 
 ### iRODS in Breniac
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # CESM/CIME configuration for SISC HPC
 
-CESM/CIME is used directly from the source code. Researches will clone some release or development version of CESM, grab additional sources for CIME in external repos and use that ensemble to create, build and run simulations (*aka* cases). Therefore, it is not possible to seamlessly adapt the software to our clusters. Users have to manually add the configuration settings and any other modifications needed to use CESM in the clusters.
+CESM/CIME is used directly from its source code. Researches will clone some release or development version of CESM, grab additional sources for CIME in external repos and use that ensemble to create, build and run simulations (*aka* cases). Therefore, it is not possible to seamlessly adapt the software to our clusters. Users will have to manually add the configuration settings and any other modifications needed to use CESM in the clusters.
 
 The versions of CESM and CIME are not tied between them. On the side of CESM the situation is clear as there are [release versions available](https://github.com/ESCOMP/CESM/releases). Users will usually download one of the stable release. However, on the side of CIME, it is more complicated. The common procedure is to download CIME using the script `checkout_externals` from CESM, which downloads the most recent version of CIME compatible with the current version of CESM. In practice, this means that the version of CIME depends on the date and time that it was downloaded and hence, the user might not be aware of what version of CIME is actually using.
 
 ## User documentation
 
-User documentation can be found at https://hpc.vub.be/documentation/software.html#how-can-i-use-cesm
+User documentation can be found at https://hpc.vub.be/documentation/software.html#how-can-i-use-cesm-cime
 
 ## Machine files
 
-XML files configuring the system environment
+XML files configuring the system environment for CIME. All files are located in `cime/config/cesm/machines/`.
+
 * config_machines.xml
     * regex to identify the system machine
     * file structure: location of input data, case folders and case output
@@ -59,7 +60,9 @@ All three machine files (*machines*, *compilers* and *batch*) have to be updated
 
 ## File structure
 
-All paths defined in `config_machines.xml` are below `$VSC_SCRATCH`. These folders contain everything from the executables, to input and output data. Moreover, CESM can generate rather big cases reaching several hundreds of GB.
+All paths defined in `config_machines.xml` are below `$VSC_SCRATCH`. These folders contain everything including the executables, input data sets, thecases and their output. CESM can generate rather big cases reaching several hundreds of GB. The structure is divided in two main folders
+* `cesm` contains all those files that are suitable to be share by multiple members of the research group (*ie* input data sets)
+* `cime` contains user generated data, including the cases generated with CIME, their output and the source code of CESM/CIME
 
 ```
 $VSC_SCRATCH
@@ -82,7 +85,7 @@ The contents of the input data are mainly historical weather records, being acti
 
 ### Projects in Hydra
 
-In Hydra, the collection of input data files can be stored in research group's `/projects` and users can link their `DIN_LOC_ROOT` in `$VSC_SCRATCH` to it. This storage is as fast as `$VSC_SCRATCH` and can be used during the execution of the case without hindering its performance.
+In Hydra, the collection of input data files can be stored in the research group's own Virtual Organization (VO). Users can simply link their `DIN_LOC_ROOT` in `$VSC_SCRATCH` to it. This storage is as fast as `$VSC_SCRATCH` and can be used during the execution of the case without hindering its performance.
 
 ### iRODS in Breniac
 
@@ -140,7 +143,7 @@ The example job script in `scripts/case.job` solves this problem by executing al
 * CESM-tools loads software commonly used to analyse the results of the simulations
     * `CESM-tools-2-foss-2019a.eb` is available in Hydra
 
-Our easyconfigs of CESM-deps are based on those available in [EasyBuild](https://github.com/easybuilders/easybuild-easyconfigs/tree/master/easybuild/easyconfigs/c/CESM-deps). However, the CESM-deps module in Hydra also contains the configuration files and scripts from this repository, which are located in the installation directory (`$EBROOTCESMMINDEPS`). Hence, our users have direct access to these files once `CESM-deps-2-foss-2019a.eb` is loaded. The usage instructions of our CESM-deps modules also provide a minimum set of instructions to create cases in Hydra with this configuration files.
+Our easyconfigs of CESM-deps are based on those available in [EasyBuild](https://github.com/easybuilders/easybuild-easyconfigs/tree/master/easybuild/easyconfigs/c/CESM-deps). However, the CESM-deps module in Hydra and Breniac also contains the configuration files and scripts from this repository, which are located in the installation directory (`$EBROOTCESMMINDEPS`). Hence, our users have direct access to these files once `CESM-deps/2-foss-2019a` or `CESM-dep/2-intel-2018a` is loaded. The usage instructions of our CESM-deps modules also provide a minimum set of instructions to create cases with this configuration files.
 
 ## CPRNC
 

--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ The example job script in `scripts/case.job` solves this problem by executing al
 ## Easyconfigs
 
 * CESM-deps loads all dependencies to build and run CESM cases
-    * `CESM-deps-2-intel-2018a.eb` is used in Breniac
-    * `CESM-deps-2-foss-2019a.eb` is used in Hydra
+    * `CESM-deps-2-intel-2019b.eb` is used in Breniac
+    * `CESM-deps-2-intel-2019b.eb` is used in Hydra
 
 * CESM-tools loads software commonly used to analyse the results of the simulations
     * `CESM-tools-2-foss-2019a.eb` is available in Hydra
 
-Our easyconfigs of CESM-deps are based on those available in [EasyBuild](https://github.com/easybuilders/easybuild-easyconfigs/tree/master/easybuild/easyconfigs/c/CESM-deps). However, the CESM-deps module in Hydra and Breniac also contains the configuration files and scripts from this repository, which are located in the installation directory (`$EBROOTCESMMINDEPS`). Hence, our users have direct access to these files once `CESM-deps/2-foss-2019a` or `CESM-dep/2-intel-2018a` is loaded. The usage instructions of our CESM-deps modules also provide a minimum set of instructions to create cases with this configuration files.
+Our easyconfigs of CESM-deps are based on those available in [EasyBuild](https://github.com/easybuilders/easybuild-easyconfigs/tree/master/easybuild/easyconfigs/c/CESM-deps). However, the CESM-deps module in Hydra and Breniac also contains the configuration files and scripts from this repository, which are located in the installation directory (`$EBROOTCESMMINDEPS`). Hence, our users have direct access to these files once `CESM-dep/2-intel-2019b` is loaded. The usage instructions of our CESM-deps modules also provide a minimum set of instructions to create cases with this configuration files.
 
 ## CPRNC
 
@@ -151,7 +151,7 @@ There is small tool called [cprnc](https://github.com/ESMCI/cime/tree/master/too
 
 These are the steps to compile this tool
 
-1. Load the CESM-deps/2-foss-2019a module
+1. Load the CESM-deps/2-intel-2019b module
 2. Prepare the source code tree of CESM as usual (as explained in our documentation)
 3. Change to source folder: `cd $VSC_SCRACTH/cime/cesm-x.y.z/cime/tools/cprnc/`
 4. Configure: `CIMEROOT=../.. ../configure --macros-format=Makefile`
@@ -171,7 +171,7 @@ The binary installed in `CCSM_CPRNC` will be used in all nodes in the cluster. T
 
 Compilation instructions for the CLM tool `mksurfdata_map`
 
-1. Load the CESM-deps/2-foss-2019a module
+1. Load the CESM-deps/2-intel-2019b module
 2. Go to the mksurfdata_map source directory: `cd $VSC_SCRACTH/cime/cesm-x.y.z/components/clm/tools/mksurfdata_map/src`
 3. Build `mksurfdata_map` with the following command
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,18 @@ The binary installed in `CCSM_CPRNC` will be used in all nodes in the cluster. T
 * the binary for Hydra was built in an IvyBridge CPU (available upon request)
 * the binary for Breniac was built in a Broadwell CPU (available upon request)
 
+## mksurfdata_map
+
+Compilation instructions for the CLM tool `mksurfdata_map`
+
+1. Load the CESM-deps/2-foss-2019a module
+2. Go to the mksurfdata_map source directory: `cd $VSC_SCRACTH/cime/cesm-x.y.z/components/clm/tools/mksurfdata_map/src`
+3. Build `mksurfdata_map` with the following command
+
+```
+$ USER_FC=gfortran LIB_NETCDF="$EBROOTNETCDFMINFORTRAN/lib" INC_NETCDF="$EBROOTNETCDFMINFORTRAN/include" USER_FFLAGS="-fno-range-check" make
+```
+
 ## Validation of the CESM installation
 
 We have carried out a scientific validation of the CESM installation in Hydra and Breniac to verify the reliability of the results obtained with it. The procedure is described in http://www.cesm.ucar.edu/models/cesm2/python-tools/.

--- a/easyconfigs/CESM-deps/CESM-deps-2-foss-2019a.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-foss-2019a.eb
@@ -9,8 +9,10 @@ description = """CESM is a fully-coupled, community, global climate model that p
 
 toolchain = {'name': 'foss', 'version': '2019a'}
 
+# install extra tools to configure CESM
 source_urls = ['https://github.com/sisc-hpc/cesm-config/archive/']
 sources = ['v1.3.tar.gz']
+checksums = ['16cc661429df8b687fee3095f1a4a86fe76c71042a067d6f06bf5e59cf7b2e38']
 
 dependencies = [
     ('CMake', '3.13.3'),

--- a/easyconfigs/CESM-deps/CESM-deps-2-intel-2018a.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-intel-2018a.eb
@@ -9,8 +9,10 @@ description = """CESM is a fully-coupled, community, global climate model that p
 
 toolchain = {'name': 'intel', 'version': '2018a'}
 
+# install extra tools to configure CESM
 source_urls = ['https://github.com/sisc-hpc/cesm-config/archive/']
 sources = ['v1.3.tar.gz']
+checksums = ['16cc661429df8b687fee3095f1a4a86fe76c71042a067d6f06bf5e59cf7b2e38']
 
 dependencies = [
     ('CMake', '3.11.4'),

--- a/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
@@ -1,0 +1,43 @@
+easyblock = 'Tarball'
+
+name = 'CESM-deps'
+version = '2'
+
+homepage = 'http://www.cesm.ucar.edu/models/cesm2/'
+description = """CESM is a fully-coupled, community, global climate model that provides state-of-the-art
+ computer simulations of the Earth's past, present, and future climate states."""
+
+toolchain = {'name': 'intel', 'version': '2019b'}
+
+# install extra tools to configure CESM
+source_urls = ['https://github.com/sisc-hpc/cesm-config/archive/']
+sources = ['v1.4.tar.gz']
+
+dependencies = [
+    ('CMake', '3.15.3'),
+    ('Python', '2.7.16'),
+    ('lxml', '4.4.2'),
+    ('Perl', '5.30.0'),
+    ('XML-LibXML', '2.0201'),
+    ('Pylint', '1.9.5', '-Python-2.7.16'),
+    ('ESMF', '8.0.0'),
+    ('netCDF', '4.7.1'),
+    ('netCDF-Fortran', '4.5.2'),
+    ('netCDF-C++4', '4.3.1'),
+    ('Subversion', '1.14.0'),
+    ('git', '2.23.0', '-nodocs'),
+    ('git-lfs', '2.11.0', '', True),
+]
+
+sanity_check_paths = {
+    'files': ['bin/update-cesm-machines', 'scripts/case.job'],
+    'dirs': ['machines', 'irods'],
+}
+
+usage = """Environment to build and run CESM v2 simulations
+ - Download a release of CESM v2: `git clone -b release-cesm2.2.0 https://github.com/ESCOMP/cesm.git cesm-2.2.0`
+ - Download external programs for CESM: `cd cesm-2.2.0; ./manage_externals/checkout_externals`
+ - Copy config files for Breniac: `cp $EBROOTCESMMINDEPS/machines/2.1/config_*.xml cime/config/cesm/machines/`
+ - Create case: `cd cime/scripts && ./create_newcase --machine breniac ...`"""
+
+moduleclass = 'geo'

--- a/irods/cime-5.8.32/01-CIME-fix-download-server-fallback.patch
+++ b/irods/cime-5.8.32/01-CIME-fix-download-server-fallback.patch
@@ -1,0 +1,85 @@
+check_input_data() only considers the download attempt of the last missing file
+to fallback to other servers. This patch fixes the fallback mechanism to jump
+to the following server in the list if any of the missing files fails to download.
+author: Alex Domingo (Vrije Universiteit Brussel)
+--- a/cime/scripts/lib/CIME/case/check_input_data.py	2020-10-02 15:33:31.521510471 +0200
++++ b/cime/scripts/lib/CIME/case/check_input_data.py	2020-10-02 16:14:08.900356030 +0200
+@@ -285,7 +285,8 @@
+     if not data_list_files:
+         logger.warning("WARNING: No .input_data_list files found in dir '{}'".format(data_list_dir))
+ 
+-    no_files_missing = True
++    chksum_required = ["svn", "gftp", "ftp", "wget"]
++
+     if download:
+         if protocol not in vars(CIME.Servers):
+             logger.info("Client protocol {} not enabled".format(protocol))
+@@ -304,6 +305,7 @@
+         if not server:
+             return None
+ 
++    installation_status = True
+     for data_list_file in data_list_files:
+         logger.info("Loading input file list: '{}'".format(data_list_file))
+         with open(data_list_file, "r") as fd:
+@@ -318,6 +320,7 @@
+                 if description.endswith('datapath') or description.endswith('data_path'):
+                     continue
+                 if(full_path):
++                    file_installed = False
+                     # expand xml variables
+                     full_path = case.get_resolved_value(full_path)
+                     rel_path = full_path
+@@ -343,8 +346,8 @@
+                             print("Model {} missing file {} = '{}'".format(model, description, full_path))
+                             if download:
+                                 logger.warning("    Cannot download file since it lives outside of the input_data_root '{}'".format(input_data_root))
+-                            no_files_missing = False
+                         else:
++                            file_installed = True
+                             logger.debug("  Found input file: '{}'".format(full_path))
+                     else:
+                         # There are some special values of rel_path that
+@@ -357,28 +360,32 @@
+ 
+                         if ("/" in rel_path and not os.path.exists(full_path) and not full_path.startswith('unknown')):
+                             print("Model {} missing file {} = '{}'".format(model, description, full_path))
+-                            no_files_missing = False
+                             if (download):
+                                 if use_ic_path:
+-                                    no_files_missing = _download_if_in_repo(server,
+-                                                                            input_ic_root, rel_path.strip(os.sep),
+-                                                                            isdirectory=isdirectory, ic_filepath=ic_filepath)
++                                    file_installed = _download_if_in_repo(server,
++                                                                          input_ic_root, rel_path.strip(os.sep),
++                                                                          isdirectory=isdirectory, ic_filepath=ic_filepath)
+                                 else:
+-                                    no_files_missing = _download_if_in_repo(server,
+-                                                                            input_data_root, rel_path.strip(os.sep),
+-                                                                            isdirectory=isdirectory, ic_filepath=ic_filepath)
+-                                if no_files_missing and chksum:
++                                    file_installed = _download_if_in_repo(server,
++                                                                          input_data_root, rel_path.strip(os.sep),
++                                                                          isdirectory=isdirectory, ic_filepath=ic_filepath)
++                                if file_installed and protocol in chksum_required:
+                                     verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)
+                         else:
+-                            if chksum:
++                            if chksum and protocol in chksum_required:
+                                 verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)
+                                 logger.info("Chksum passed for file {}".format(os.path.join(input_data_root,rel_path)))
++                            file_installed = True
+                             logger.debug("  Already had input file: '{}'".format(full_path))
++
++                    if not file_installed:
++                        installation_status = False
++
+                 else:
+                     model = os.path.basename(data_list_file).split('.')[0]
+                     logger.warning("Model {} no file specified for {}".format(model, description))
+ 
+-    return no_files_missing
++    return installation_status
+ 
+ def verify_chksum(input_data_root, rundir, filename, isdirectory):
+     """

--- a/irods/cime-5.8.32/02-CIME-add-irods-server.patch
+++ b/irods/cime-5.8.32/02-CIME-add-irods-server.patch
@@ -1,0 +1,138 @@
+Add support for iRODS servers as sources of input data files.
+author: Alex Domingo (Vrije Universiteit Brussel)
+--- a/cime/config/cesm/config_inputdata.xml	2020-10-02 15:33:31.274236000 +0200
++++ b/cime/config/cesm/config_inputdata.xml	2020-10-02 16:24:47.387943000 +0200
+@@ -7,6 +7,16 @@
+   <!-- inputdata_chksum.dat is found on the server in the directory above inputdata -->
+   <!-- it will be searched for filename and chksum of each downloaded file.  -->
+   <!-- see the file ftp://ftp.cgd.ucar.edu/cesm/inputdata_chksum.dat for proper format. -->
++
++  <!-- iRODS automatically verifies checksums. However, CESM still needs to have something in <checksum> -->
++  <!-- It will look for that checksum file and if it does not exist it just won't use it -->
++  <server>
++    <comment>iRODS requires an active open session with your iRODS server</comment>
++    <protocol>irods</protocol>
++    <address>i:cesm/inputdata</address>
++    <checksum>../inputdata_checksum.dat</checksum>
++  </server>
++
+   <server>
+     <comment>grid ftp requires the globus-url-copy tool on the client side </comment>
+     <protocol>gftp</protocol>
+--- a/cime/scripts/lib/CIME/case/check_input_data.py	2020-10-02 16:22:32.964876000 +0200
++++ b/cime/scripts/lib/CIME/case/check_input_data.py	2020-10-02 16:26:48.788185396 +0200
+@@ -35,6 +35,8 @@
+             server = CIME.Servers.FTP.ftp_login(address, user, passwd)
+         elif protocol == "wget":
+             server = CIME.Servers.WGET.wget_login(address, user, passwd)
++        elif protocol == "irods":
++            server = CIME.Servers.IRODS.irods_login(address, user, passwd)
+         else:
+             expect(False, "Unsupported inputdata protocol: {}".format(protocol))
+         if not server:
+@@ -300,6 +302,8 @@
+             server = CIME.Servers.FTP.ftp_login(address, user, passwd)
+         elif protocol == "wget":
+             server = CIME.Servers.WGET.wget_login(address, user, passwd)
++        elif protocol == "irods":
++            server = CIME.Servers.IRODS.irods_login(address, user, passwd)
+         else:
+             expect(False, "Unsupported inputdata protocol: {}".format(protocol))
+         if not server:
+--- a/cime/scripts/lib/CIME/Servers/__init__.py	2020-10-02 15:33:31.451774000 +0200
++++ b/cime/scripts/lib/CIME/Servers/__init__.py	2020-10-02 16:32:09.316233000 +0200
+@@ -3,6 +3,7 @@
+ has_gftp = find_executable("globus-url-copy")
+ has_svn = find_executable("svn")
+ has_wget = find_executable("wget")
++has_irods = find_executable("irsync")
+ has_ftp = True
+ try:
+     from ftplib import FTP
+@@ -14,5 +15,7 @@
+     from CIME.Servers.svn import SVN
+ if has_wget:
+     from CIME.Servers.wget import WGET
++if has_irods:
++    from CIME.Servers.irods import IRODS
+ if has_gftp:
+     from CIME.Servers.gftp import GridFTP
+--- a/cime/scripts/lib/CIME/Servers/irods.py	1970-01-01 01:00:00.000000000 +0100
++++ b/cime/scripts/lib/CIME/Servers/irods.py	2020-10-02 16:27:14.885415000 +0200
+@@ -0,0 +1,76 @@
++"""
++iRODS Server class.  Interact with a server using WGET protocol
++"""
++# pylint: disable=super-init-not-called
++from CIME.XML.standard_module_setup import *
++from CIME.Servers.generic_server import GenericServer
++logger = logging.getLogger(__name__)
++
++
++class IRODS(GenericServer):
++    def __init__(self, address, user='', passwd=''):
++        self._args = '-K'  # verify checksums
++        self._server_loc = address
++
++    @classmethod
++    def irods_login(cls, address, user='', passwd=''):
++        args = ''
++
++        try:
++            err = run_cmd("ils {}".format(address[2:]), timeout=60)[0]  # ils does not need 'i:' prefix
++        except:
++            logger.warning("Could not access iRODS collection '{0}'".format(address))
++            return None
++        if err:
++            logger.warning("Could not access iRODS collection '{0}'".format(address))
++            return None
++
++
++        return cls(address, user=user, passwd=passwd)
++
++    def fileexists(self, rel_path):
++        full_url = os.path.join(self._server_loc, rel_path)
++        stat, out, err = run_cmd("irsync {} {}".format(self._args, full_url))
++
++        if (stat != 0):
++            logging.warning("FAIL: iRODS collection '{}' does not have file '{}'\nReason:{}\n{}\n".format(self._server_loc, full_url, out.encode('utf-8'), err.encode('utf-8')))
++            return False
++        return True
++
++    def getfile(self, rel_path, full_path):
++        full_url = os.path.join(self._server_loc, rel_path)
++        irods_cmd = "irsync {} {} {}".format(self._args, full_url, full_path)
++        stat, output, errput = run_cmd(irods_cmd)
++        if (stat != 0):
++            logging.warning("{} failed with output: {} and errput {}\n".format(
++                irods_cmd, output.encode('utf-8'), errput.encode('utf-8')
++            ))
++            # file might be empty or partially downloaded if it fails
++            try:
++                os.remove(full_path)
++            except OSError:
++                pass
++            return False
++        else:
++            logging.info("SUCCESS\n")
++            return True
++
++    def getdirectory(self, rel_path, full_path):
++        full_url = os.path.join(self._server_loc, rel_path)
++        irods_cmd = "irsync {} -r {} ./".format(self._args, full_url+os.sep)
++        stat, output, errput = run_cmd(irods_cmd, from_dir=full_path)
++        logger.debug(output)
++        logger.debug(errput)
++        if (stat != 0):
++            logging.warning("{} failed with output: {} and errput {}\n".format(
++                irods_cmd, output.encode('utf-8'), errput.encode('utf-8')
++            ))
++            # dir might be empty or partially downloaded if it fails
++            try:
++                os.remove(full_path)
++            except OSError:
++                pass
++            return False
++        else:
++            logging.info("SUCCESS\n")
++            return True

--- a/irods/cime-5.8.32/03-CIME-archive-inputdata-irods.patch
+++ b/irods/cime-5.8.32/03-CIME-archive-inputdata-irods.patch
@@ -1,0 +1,50 @@
+Sync the local input data folder with the remote iRODS server in the archival step
+author: Alex Domingo (Vrije Universiteit Brussel)
+--- a/cime/config/cesm/machines/config_workflow.xml	2020-10-02 15:33:31.288779000 +0200
++++ b/cime/config/cesm/machines/config_workflow.xml	2020-10-02 16:57:12.850536000 +0200
+@@ -44,8 +44,8 @@
+       <prereq>$DOUT_S</prereq>
+       <runtime_parameters>
+ 	<task_count>1</task_count>
+-	<tasks_per_node>1</tasks_per_node>
+-	<walltime>0:20:00</walltime>
++	<tasks_per_node>4</tasks_per_node>
++	<walltime>12:00:00</walltime>
+       </runtime_parameters>
+     </job>
+   </workflow_jobs>
+--- a/cime/config/cesm/machines/template.st_archive	2020-10-02 15:33:31.291523000 +0200
++++ b/cime/config/cesm/machines/template.st_archive	2020-10-02 16:58:26.528175000 +0200
+@@ -17,6 +17,8 @@
+ 
+ from standard_script_setup          import *
+ from CIME.case import Case
++from CIME.utils import run_cmd
++from CIME.XML.inputdata import Inputdata
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -89,6 +91,23 @@
+                                            archive_incomplete_logs=not no_incomplete_logs,
+                                            copy_only=copy_only, resubmit=resubmit)
+ 
++        # Upload any new input files to iRODS
++        inputdata = Inputdata()
++        protocol = None
++        while protocol != 'irods':
++            protocol, address, _, _, _ = inputdata.get_next_server()
++
++        irods_sync_cmd = "irsync -K -r {} {}".format(case.get_value('DIN_LOC_ROOT'), address)
++        logging.info("Synchronizing local inputdata to iRODS: %s ...\n", irods_sync_cmd)
++        stat, output, errput = run_cmd(irods_sync_cmd)
++        if (stat != 0):
++            logging.warning(
++                "irsync failed with output: {} and errput {}\n".format(output.encode('utf-8'), errput.encode('utf-8'))
++            )
++        else:
++            logging.info("Synchronization completed successfully\n")
++            logging.debug("%s\n", output)
++
+     sys.exit(0 if success else 1)
+ 
+ ###############################################################################

--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -39,7 +39,7 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
 
   <batch_system MACH="hydra" type="pbs">
     <directives>
-      <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
+      <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}:skylake</directive>
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>

--- a/machines/config_compilers.xml
+++ b/machines/config_compilers.xml
@@ -37,9 +37,20 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
 
 <config_compilers>
 
-  <compiler MACH="hydra" COMPILER="gnu">
+  <compiler MACH="hydra" COMPILER="intel">
+    <MPICC> mpiicc  </MPICC>
+    <MPICXX> mpiicpc </MPICXX>
+    <MPIFC> mpiifort </MPIFC>
+    <SCC> icc </SCC>
+    <SCXX> icpc </SCXX>
+    <SFC> ifort </SFC>
+    <CFLAGS>
+      <append DEBUG="FALSE"> -xCOMMON-AVX512 -no-fma </append>
+    </CFLAGS>
+    <FFLAGS>
+      <append DEBUG="FALSE"> -xCOMMON-AVX512 -no-fma </append>
+    </FFLAGS>
     <SLIBS>
-      <append> -L$ENV{EBROOTSCALAPACK}/lib -lscalapack -L$ENV{EBROOTOPENBLAS}/lib -lopenblas </append>
       <append> -L$ENV{EBROOTNETCDFMINFORTRAN}/lib -lnetcdff -L$ENV{EBROOTNETCDF}/lib64 -lnetcdf </append>
     </SLIBS>
     <ESMF_LIBDIR>$ENV{EBROOTESMF}/lib</ESMF_LIBDIR>
@@ -57,15 +68,15 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     <SCC> icc </SCC>
     <SCXX> icpc </SCXX>
     <SFC> ifort </SFC>
+    <CFLAGS>
+      <append DEBUG="FALSE"> -xCORE_AVX2 -no-fma </append>
+    </CFLAGS>
+    <FFLAGS>
+      <append DEBUG="FALSE"> -xCORE_AVX2 -no-fma </append>
+    </FFLAGS>
     <SLIBS>
       <append> -L$ENV{EBROOTNETCDFMINFORTRAN}/lib -lnetcdff -L$ENV{EBROOTNETCDF}/lib64 -lnetcdf </append>
     </SLIBS>
-    <CFLAGS>
-      <append DEBUG="FALSE"> -O2 -xCORE_AVX2 -no-fma </append>
-    </CFLAGS>
-    <FFLAGS>
-      <append DEBUG="FALSE"> -O2 -xCORE_AVX2 -no-fma </append>
-    </FFLAGS>
     <ESMF_LIBDIR>$ENV{EBROOTESMF}/lib</ESMF_LIBDIR>
     <NETCDF_PATH>$ENV{EBROOTNETCDF}</NETCDF_PATH>
     <NETCDF_C_PATH>$ENV{EBROOTNETCDFMINCPLUSPLUS4}</NETCDF_C_PATH>
@@ -81,10 +92,10 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     <SCXX> icpc </SCXX>
     <SFC> ifort </SFC>
     <CFLAGS>
-      <append DEBUG="FALSE"> -O2 -xCOMMON-AVX512 -no-fma </append>
+      <append DEBUG="FALSE"> -xCOMMON-AVX512 -no-fma </append>
     </CFLAGS>
     <FFLAGS>
-      <append DEBUG="FALSE"> -O2 -xCOMMON-AVX512 -no-fma </append>
+      <append DEBUG="FALSE"> -xCOMMON-AVX512 -no-fma </append>
     </FFLAGS>
     <SLIBS>
       <append> -L$ENV{EBROOTNETCDFMINFORTRAN}/lib -lnetcdff -L$ENV{EBROOTNETCDF}/lib64 -lnetcdf </append>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -39,10 +39,10 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
 
   <machine MACH="hydra">
     <DESC> Hydra - heterogeneous cluster at VUB, batch system is PBS</DESC>
-    <NODENAME_REGEX>(node.*\.hydra\.(os|brussel\.vsc)|login.*\.cerberus\.os)</NODENAME_REGEX>
+    <NODENAME_REGEX>(node3.*\.hydra\.(os|brussel\.vsc)|login.*\.cerberus\.os)</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>openmpi</MPILIBS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>impi</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{VSC_SCRATCH}/cime/output</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{VSC_SCRATCH}/cesm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>$ENV{VSC_SCRATCH}/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -55,8 +55,8 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
     <MAX_TASKS_PER_NODE>20</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>20</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-    <mpirun mpilib="openmpi">
-      <executable>mpiexec</executable>
+    <mpirun mpilib="impi">
+      <executable>mpirun</executable>
     </mpirun>
     <module_system type="module">
       <init_path lang="perl">/usr/share/lmod/lmod/init/perl</init_path>
@@ -69,18 +69,15 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">XML-LibXML/2.0200-GCCcore-8.2.0-Perl-5.28.1</command>
-        <command name="load">Python/2.7.15-GCCcore-8.2.0</command>
-        <command name="load">CMake/3.13.3-GCCcore-8.2.0</command>
-        <command name="load">git/2.21.0-GCCcore-8.2.0</command>
+        <command name="load">XML-LibXML/2.0201-GCCcore-8.3.0</command>
+        <command name="load">Python/2.7.16-GCCcore-8.3.0</command>
+        <command name="load">CMake/3.15.3-GCCcore-8.3.0</command>
+        <command name="load">git/2.23.0-GCCcore-8.3.0-nodocs</command>
       </modules>
-      <modules compiler="gnu">
-        <command name="load">CESM-deps/2-foss-2019a</command>
+      <modules compiler="intel">
+        <command name="load">CESM-deps/2-intel-2019b</command>
       </modules>
     </module_system>
-    <environment_variables>
-      <env name="OMP_STACKSIZE">256M</env>
-    </environment_variables>
   </machine>
 
   <machine MACH="breniac">

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -112,18 +112,15 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">XML-LibXML/2.0132-GCCcore-6.4.0-Perl-5.26.1</command>
-        <command name="load">Python/2.7.14-intel-2018a</command>
-        <command name="load">CMake/3.11.4-GCCcore-6.4.0</command>
-        <command name="load">git/2.16.1-GCCcore-6.4.0</command>
+        <command name="load">XML-LibXML/2.0201-GCCcore-8.3.0</command>
+        <command name="load">Python/2.7.16-GCCcore-8.3.0</command>
+        <command name="load">CMake/3.15.3-GCCcore-8.3.0</command>
+        <command name="load">git/2.23.0-GCCcore-8.3.0-nodocs</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">CESM-deps/2-intel-2018a</command>
+        <command name="load">CESM-deps/2-intel-2019b</command>
       </modules>
     </module_system>
-    <environment_variables>
-      <env name="OMP_STACKSIZE">256M</env>
-    </environment_variables>
   </machine>
 
   <machine MACH="breniac-skl">
@@ -158,18 +155,15 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
       <cmd_path lang="csh">module</cmd_path>
       <modules>
         <command name="purge"/>
-        <command name="load">XML-LibXML/2.0132-GCCcore-6.4.0-Perl-5.26.1</command>
-        <command name="load">Python/2.7.14-intel-2018a</command>
-        <command name="load">CMake/3.11.4-GCCcore-6.4.0</command>
-        <command name="load">git/2.16.1-GCCcore-6.4.0</command>
+        <command name="load">XML-LibXML/2.0201-GCCcore-8.3.0</command>
+        <command name="load">Python/2.7.16-GCCcore-8.3.0</command>
+        <command name="load">CMake/3.15.3-GCCcore-8.3.0</command>
+        <command name="load">git/2.23.0-GCCcore-8.3.0-nodocs</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">CESM-deps/2-intel-2018a</command>
+        <command name="load">CESM-deps/2-intel-2019b</command>
       </modules>
     </module_system>
-    <environment_variables>
-      <env name="OMP_STACKSIZE">256M</env>
-    </environment_variables>
   </machine>
 
 </config_machines>


### PR DESCRIPTION
Changelog:
* new set of patches for iRODS covering CIME v5.8.32
* new easyconfig for CESM-desp/2-intel-2019b that will be used in Hydra and Breniac
* config files for Hydra and Breniac enabling CESM-desp/2-intel-2019b
* updates to the README