### PR TITLE
fix git module in Breniac

### DIFF
--- a/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
+++ b/easyconfigs/CESM-deps/CESM-deps-2-intel-2019b.eb
@@ -11,7 +11,7 @@ toolchain = {'name': 'intel', 'version': '2019b'}
 
 # install extra tools to configure CESM
 source_urls = ['https://github.com/sisc-hpc/cesm-config/archive/']
-sources = ['v1.4.tar.gz']
+sources = ['v1.4.1.tar.gz']
 
 dependencies = [
     ('CMake', '3.15.3'),

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -115,7 +115,7 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
         <command name="load">XML-LibXML/2.0201-GCCcore-8.3.0</command>
         <command name="load">Python/2.7.16-GCCcore-8.3.0</command>
         <command name="load">CMake/3.15.3-GCCcore-8.3.0</command>
-        <command name="load">git/2.23.0-GCCcore-8.3.0-nodocs</command>
+        <command name="load">git/2.30.1-GCCcore-8.3.0</command>
       </modules>
       <modules compiler="intel">
         <command name="load">CESM-deps/2-intel-2019b</command>
@@ -158,7 +158,7 @@ Author: Alex Domingo (Vrije Universiteit Brussel)
         <command name="load">XML-LibXML/2.0201-GCCcore-8.3.0</command>
         <command name="load">Python/2.7.16-GCCcore-8.3.0</command>
         <command name="load">CMake/3.15.3-GCCcore-8.3.0</command>
-        <command name="load">git/2.23.0-GCCcore-8.3.0-nodocs</command>
+        <command name="load">git/2.30.1-GCCcore-8.3.0</command>
       </modules>
       <modules compiler="intel">
         <command name="load">CESM-deps/2-intel-2019b</command>


### PR DESCRIPTION
The `CESM-deps/2-intel-2019b` module in Breniac was installed with a different version of `git` requiring to update the machine configuration file.

This will be part of a bugfix release v1.4.1